### PR TITLE
CD - update terraform version, trigger dev environment update

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,8 +45,6 @@ jobs:
         run: |
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
-#          git clone https://github.com/bitmatica/cloud_infrastructure.git
-#          cd cloud_infrastructure/blogmatica/dev
           cd $GITHUB_WORKSPACE/cloud_infrastructure/blogmatica/dev
           echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > backend_version.txt
           git add backend_version.txt

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,12 +45,12 @@ jobs:
           IMAGE_URI: ${{ steps.build-push-image.outputs.IMAGE_URI }}
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
           TERRAFORM_REPO_ORG: ${{ secrets.TERRAFORM_REPO_ORG }}
+          TERRAFORM_REPO_VERSION_PATH: ${{ secrets.TERRAFORM_REPO_VERSION_PATH }}
         run: |
           git config --global user.email "github-actions@$TERRAFORM_REPO_ORG.com"
           git config --global user.name "github actions"
-          echo "path: $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH"
-          echo -n "$IMAGE_URI" > "$GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH"
-          git add $TERRAFORM_REPO_VERSION_PATH
+          echo -n "$IMAGE_URI" > $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH
+          git add $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH
           git commit -m "Update dev version to $IMAGE_URI"
           git push origin master
           echo "Dev version updated in terraform.  See https://github.com/$TERRAFORM_REPO_ORG/$TERRAFORM_REPO_NAME/actions for deploy progress"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,25 +37,25 @@ jobs:
       - name: Checkout Terraform Repo
         uses: actions/checkout@v2
         with:
-          repository: bitmatica/${{ secrets.TERRAFORM_REPO_NAME }}
+          repository: ${{ secrets.TERRAFORM_REPO_ORG }}/${{ secrets.TERRAFORM_REPO_NAME }}
           ssh-key: ${{ secrets.TERRAFORM_DEPLOY_KEY }}
           path: ${{ secrets.TERRAFORM_REPO_NAME }}
       - name: Update Dev Environment with new Image Tag
         env:
           IMAGE_URI: ${{ steps.build-push-image.outputs.IMAGE_URI }}
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
+          TERRAFORM_REPO_ORG: ${{ secrets.TERRAFORM_REPO_ORG }}
         run: |
           echo "github.organization: $github.organization"
           echo "github.org: $github.org"
           echo "github.repository: $github.repository"
-          git config --global user.email "github-actions@bitmatica.com"
+          git config --global user.email "github-actions@$TERRAFORM_REPO_ORG.com"
           git config --global user.name "github actions"
-          cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/blogmatica/dev
-          echo -n "$IMAGE_URI" > backend_version.txt
-          git add backend_version.txt
+          echo -n "$IMAGE_URI" > $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH
+          git add $TERRAFORM_REPO_VERSION_PATH
           git commit -m "Update dev version to $IMAGE_URI"
           git push origin master
-          echo "Dev version updated in terraform.  See https://github.com/bitmatica/$TERRAFORM_REPO_NAME/actions for deploy progress"
+          echo "Dev version updated in terraform.  See https://github.com/$TERRAFORM_REPO_ORG/$TERRAFORM_REPO_NAME/actions for deploy progress"
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          path: main
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -27,8 +29,14 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $GITHUB_WORKSPACE
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $GITHUB_WORKSPACE/main
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      - name: Checkout cloud_infrastructure
+        uses: actions/checkout@v2
+        with:
+          repository: bitmatica/cloud_infrastructure
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB }}
+          path: cloud_infrastructure
       - name: Update Dev Environment with new Image Tag
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -37,8 +45,9 @@ jobs:
         run: |
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
-          git clone https://github.com/bitmatica/cloud_infrastructure.git
-          cd cloud_infrastructure/blogmatica/dev
+#          git clone https://github.com/bitmatica/cloud_infrastructure.git
+#          cd cloud_infrastructure/blogmatica/dev
+          cd $GITHUB_WORKSPACE/cloud_infrastructure/blogmatica/dev
           echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > backend_version.txt
           git add backend_version.txt
           git commit -m "Update $ECR_REPOSITORY dev version to $IMAGE_TAG"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,8 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
+          git config --global user.email "github-actions@bitmatica.com"
+          git config --global user.name "github actions"
           git clone https://github.com/bitmatica/cloud_infrastructure.git
           cd cloud_infrastructure/blogmatica/dev
           echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > backend_version.txt

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,8 +49,9 @@ jobs:
         run: |
           git config --global user.email "github-actions@$TERRAFORM_REPO_ORG.com"
           git config --global user.name "github actions"
-          echo -n "$IMAGE_URI" > $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH
-          git add $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH
+          cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME
+          echo -n "$IMAGE_URI" > $TERRAFORM_REPO_VERSION_PATH
+          git add $TERRAFORM_REPO_VERSION_PATH
           git commit -m "Update dev version to $IMAGE_URI"
           git push origin master
           echo "Dev version updated in terraform.  See https://github.com/$TERRAFORM_REPO_ORG/$TERRAFORM_REPO_NAME/actions for deploy progress"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,9 @@
 name: Continuous Delivery
 # This workflow is triggered on pushes to the repository.
-on:
-  push:
-    branches:
-      - master
+on: push
+#  push:
+#    branches:
+#      - master
 
 jobs:
   build:
@@ -29,6 +29,18 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $GITHUB_WORKSPACE
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      - name: Update Dev Environment with new Image Tag
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          git clone https://github.com/bitmatica/cloud_infrastructure.git
+          cd cloud_infrastructure/blogmatica/dev
+          echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > backend_version.txt
+          git add backend_version.txt
+          git commit -m "Update $ECR_REPOSITORY dev version to $IMAGE_TAG"
+          git push origin master
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,9 @@ jobs:
           IMAGE_URI: ${{ steps.build-push-image.outputs.IMAGE_URI }}
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
         run: |
+          echo "github.organization: $github.organization"
+          echo "github.org: $github.org"
+          echo "github.repository: $github.repository"
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
           cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/blogmatica/dev

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
       - name: Build, tag, and push image to Amazon ECR
-        id: build-push-image
+        id: build-push
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
@@ -42,7 +42,7 @@ jobs:
           path: ${{ secrets.TERRAFORM_REPO_NAME }}
       - name: Update Dev Environment with new Image Tag
         env:
-          IMAGE_URI: ${{ steps.build-push-image.outputs.IMAGE_URI }}
+          IMAGE_URI: ${{ steps.build-push.outputs.IMAGE_URI }}
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
           TERRAFORM_REPO_VERSION_PATH: ${{ secrets.TERRAFORM_REPO_VERSION_PATH }}
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
           cd $GITHUB_WORKSPACE/cloud_infrastructure/blogmatica/dev
-          echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > backend_version.txt
+          echo -n "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > backend_version.txt
           git add backend_version.txt
           git commit -m "Update $ECR_REPOSITORY dev version to $IMAGE_TAG"
           git push origin master

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,12 +46,10 @@ jobs:
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
           TERRAFORM_REPO_ORG: ${{ secrets.TERRAFORM_REPO_ORG }}
         run: |
-          echo "github.organization: $github.organization"
-          echo "github.org: $github.org"
-          echo "github.repository: $github.repository"
           git config --global user.email "github-actions@$TERRAFORM_REPO_ORG.com"
           git config --global user.name "github actions"
-          echo -n "$IMAGE_URI" > $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH
+          echo "path: $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH"
+          echo -n "$IMAGE_URI" > "$GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/$TERRAFORM_REPO_VERSION_PATH"
           git add $TERRAFORM_REPO_VERSION_PATH
           git commit -m "Update dev version to $IMAGE_URI"
           git push origin master

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,6 +50,7 @@ jobs:
           git add backend_version.txt
           git commit -m "Update $ECR_REPOSITORY dev version to $IMAGE_TAG"
           git push origin master
+          echo "Dev version updated in terraform.  See https://github.com/bitmatica/cloud_infrastructure/actions for deploy progress"
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,13 +24,16 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
       - name: Build, tag, and push image to Amazon ECR
+        id: build-push-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $GITHUB_WORKSPACE/main
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          IMAGE_URI=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $IMAGE_URI $GITHUB_WORKSPACE/main
+          docker push $IMAGE_URI
+          echo "::set-output name=IMAGE_URI::$IMAGE_URI"
       - name: Checkout cloud_infrastructure
         uses: actions/checkout@v2
         with:
@@ -39,16 +42,14 @@ jobs:
           path: cloud_infrastructure
       - name: Update Dev Environment with new Image Tag
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_URI: ${{ steps.build-push-image.outputs.IMAGE_URI }}
         run: |
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
           cd $GITHUB_WORKSPACE/cloud_infrastructure/blogmatica/dev
-          echo -n "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > backend_version.txt
+          echo -n "$IMAGE_URI" > backend_version.txt
           git add backend_version.txt
-          git commit -m "Update $ECR_REPOSITORY dev version to $IMAGE_TAG"
+          git commit -m "Update dev version to $IMAGE_URI"
           git push origin master
           echo "Dev version updated in terraform.  See https://github.com/bitmatica/cloud_infrastructure/actions for deploy progress"
       - name: Logout of Amazon ECR

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,24 +34,25 @@ jobs:
           docker build -t $IMAGE_URI $GITHUB_WORKSPACE/main
           docker push $IMAGE_URI
           echo "::set-output name=IMAGE_URI::$IMAGE_URI"
-      - name: Checkout cloud_infrastructure
+      - name: Checkout Terraform Repo
         uses: actions/checkout@v2
         with:
-          repository: bitmatica/cloud_infrastructure
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-          path: cloud_infrastructure
+          repository: bitmatica/${{ secrets.TERRAFORM_REPO_NAME }}
+          ssh-key: ${{ secrets.TERRAFORM_DEPLOY_KEY }}
+          path: ${{ secrets.TERRAFORM_REPO_NAME }}
       - name: Update Dev Environment with new Image Tag
         env:
           IMAGE_URI: ${{ steps.build-push-image.outputs.IMAGE_URI }}
+          TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
         run: |
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
-          cd $GITHUB_WORKSPACE/cloud_infrastructure/blogmatica/dev
+          cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME/blogmatica/dev
           echo -n "$IMAGE_URI" > backend_version.txt
           git add backend_version.txt
           git commit -m "Update dev version to $IMAGE_URI"
           git push origin master
-          echo "Dev version updated in terraform.  See https://github.com/bitmatica/cloud_infrastructure/actions for deploy progress"
+          echo "Dev version updated in terraform.  See https://github.com/bitmatica/$TERRAFORM_REPO_NAME/actions for deploy progress"
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,17 +44,16 @@ jobs:
         env:
           IMAGE_URI: ${{ steps.build-push-image.outputs.IMAGE_URI }}
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
-          TERRAFORM_REPO_ORG: ${{ secrets.TERRAFORM_REPO_ORG }}
           TERRAFORM_REPO_VERSION_PATH: ${{ secrets.TERRAFORM_REPO_VERSION_PATH }}
         run: |
-          git config --global user.email "github-actions@$TERRAFORM_REPO_ORG.com"
+          git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
           cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME
           echo -n "$IMAGE_URI" > $TERRAFORM_REPO_VERSION_PATH
           git add $TERRAFORM_REPO_VERSION_PATH
-          git commit -m "Update dev version to $IMAGE_URI"
+          git commit -m "$GITHUB_REPOSITORY: update dev version to $IMAGE_URI"
           git push origin master
-          echo "Dev version updated in terraform.  See https://github.com/$TERRAFORM_REPO_ORG/$TERRAFORM_REPO_NAME/actions for deploy progress"
+          echo "Dev version updated in terraform.  See terraform repo's github actions for deploy progress."
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: bitmatica/cloud_infrastructure
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
           path: cloud_infrastructure
       - name: Update Dev Environment with new Image Tag
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,9 @@
 name: Continuous Delivery
 # This workflow is triggered on pushes to the repository.
-on: push
-#  push:
-#    branches:
-#      - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:lts-slim
 COPY . .
 RUN rm -rf node_modules && yarn
-RUN yarn build
 CMD [ "yarn", "start:prod" ]


### PR DESCRIPTION
Update image version (commit to master) in cloud_infrastructure repo, which triggers a dev `terraform apply` in cloud_infrastructure github action.

Prereq:
- Deploy key for infra repo (among other vars) is provisioned by terraform and added as a github action secret

Notes:
- Deploy keys are a bit better than personal access tokens in that they only give access to a repo (instead of all repos) in a github org.  But they're still too permissive (the deploy key has read/write permissions to the infra repo, so could update all infra code, even prod) - a better solution would be to have something listening for image pushes to ECR (e.g. CloudTrail) and updating the terraform repo (e.g. a Lambda function).  That was a bit more complicated though, this should be fine for dev/staging.